### PR TITLE
Hide n' Seek 4.1.1

### DIFF
--- a/extension/background/js/background.js
+++ b/extension/background/js/background.js
@@ -82,6 +82,14 @@ class Utilities {
       )
     ).join("");
   }
+
+  static async safeAwait(functionToAwait, ...args) {
+    try {
+      return await functionToAwait(...args);
+    } catch (error) {
+      console.log(error);
+    }
+  }
 }
 
 class JobBoards {
@@ -199,18 +207,20 @@ const updateBadgeTextAndTitle = async (jobBoardId) => {
   contentScriptStatusesOfJobBoardIdTabs.forEach(
     ({ tab, contentScriptStatus }) => {
       if (!contentScriptStatus.hasHideNSeekUI) {
-        chrome.action.setTitle({
+        Utilities.safeAwait(chrome.action.setTitle, {
           tabId: tab.id,
           title: "Hide n' Seek",
         });
 
-        return chrome.action.setBadgeText({
+        Utilities.safeAwait(chrome.action.setBadgeText, {
           tabId: tab.id,
           text: "",
         });
+
+        return;
       }
 
-      chrome.action.setTitle({
+      Utilities.safeAwait(chrome.action.setTitle, {
         tabId: tab.id,
         title: `Hide n' Seek
 
@@ -225,12 +235,12 @@ ${jobBoardName}:
 `,
       });
 
-      chrome.action.setBadgeBackgroundColor({
+      Utilities.safeAwait(chrome.action.setBadgeBackgroundColor, {
         tabId: tab.id,
         color: [255, 128, 128, 255],
       });
 
-      chrome.action.setBadgeText({
+      Utilities.safeAwait(chrome.action.setBadgeText, {
         tabId: tab.id,
         text: `${numberOfBlockedJobAttributes}`,
       });
@@ -246,7 +256,9 @@ chrome.runtime.onInstalled.addListener(async () => {
   const tabsWithJobBoardId = await JobBoards.getTabsWithJobBoardId();
 
   tabsWithJobBoardId.forEach((tabWithJobBoardId) =>
-    chrome.tabs.reload(tabWithJobBoardId.id, { bypassCache: true })
+    Utilities.safeAwait(chrome.tabs.reload, tabWithJobBoardId.id, {
+      bypassCache: true,
+    })
   );
 });
 
@@ -266,7 +278,7 @@ chrome.tabs.onUpdated.addListener((tabId, tabChanges, tab) => {
 
   if (!jobBoardId) return;
 
-  chrome.scripting.executeScript({
+  Utilities.safeAwait(chrome.scripting.executeScript, {
     target: { tabId },
     files: ["/content-script/js/content-script.js"],
   });
@@ -292,7 +304,7 @@ chrome.runtime.onMessage.addListener(async (message, sender) => {
   if (!message.to.includes("background script")) return;
 
   if (message.from === "content script" && message.body === "inject css") {
-    chrome.scripting.insertCSS({
+    Utilities.safeAwait(chrome.scripting.insertCSS, {
       target: { tabId: sender.tab.id },
       files: ["/content-script/css/content-script.css"],
     });

--- a/extension/background/js/background.js
+++ b/extension/background/js/background.js
@@ -300,7 +300,7 @@ chrome.storage.local.onChanged.addListener((storageChanges) => {
   });
 });
 
-chrome.runtime.onMessage.addListener(async (message, sender) => {
+chrome.runtime.onMessage.addListener((message, sender) => {
   if (!message.to.includes("background script")) return;
 
   if (message.from === "content script" && message.body === "inject css") {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Hide n' Seek",
   "description": "View the jobs you seek. Hide the ones you don't.",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "icons": {
     "16": "/images/hide-n-seek-icon-16.png",
     "32": "/images/hide-n-seek-icon-32.png",

--- a/extension/popup/js/popup.js
+++ b/extension/popup/js/popup.js
@@ -796,7 +796,7 @@
     }
   }
 
-  chrome.runtime.onMessage.addListener(async (message, sender) => {
+  chrome.runtime.onMessage.addListener((message, sender) => {
     if (!message.to.includes("popup script")) return;
 
     if (
@@ -809,11 +809,10 @@
 
       if (!messageFromActiveTabInCurrentWindow) return;
 
-      const storage = await chrome.storage.local.get();
       if (message.hasHideNSeekUI === true) {
-        ApplicableTabPopup.start(message.jobBoardId, storage);
+        ApplicableTabPopup.start(message.jobBoardId);
       } else if (message.hasHideNSeekUI === false) {
-        InapplicableTabPopup.start(activeTabInCurrentWindow, storage);
+        InapplicableTabPopup.start(activeTabInCurrentWindow);
       }
     }
   });

--- a/other-manifests/firefox/manifest.json
+++ b/other-manifests/firefox/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Hide n' Seek",
   "description": "View the jobs you seek. Hide the ones you don't.",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "icons": {
     "16": "/images/hide-n-seek-icon-16.png",
     "32": "/images/hide-n-seek-icon-32.png",


### PR DESCRIPTION
A few days after updating from 4.0.0 to 4.1.0, the Hide n' Seek UI failed to display on Indeed and LinkedIn job search tabs. 

This issue persisted even after reloading the tabs. Restarting Chrome resolved this issue, but what was the cause? Two uncaught promise rejection errors in background.js were logged:

* "No tab with id: ##########."
* "Frame with ID 0 was removed."

However, I do not know if these errors caused the issue. These errors seem to occur when background.js queries tabs, then tries to inject the content script into applicable tabs, and fails. The cause of the injection failure may be due to the use of an incorrect or obsolete tab id, in which case the tab id must have changed or was lost between tab querying and script injection.