### PR TITLE
Hide n' Seek 4.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Once finished, perform a job search on LinkedIn or Indeed. **_If you do not see 
     - 2023-05-14
   - Improvements
     - Added support for all country-specific versions of Indeed
-      - All country-specific versions of Indeed (i.e. non-US versions of Indeed) now work with Hide n' Seek. (Issue #14)
+      - All country-specific versions of Indeed (i.e. non-US versions of Indeed) now work with Hide n' Seek. ([Issue #14](https://github.com/damianmgarcia/Hide-n-Seek/issues/14))
     - Added network connectivity handling to the job search popup
       - Hide n' Seek will now automatically disable the job search popup when your device is offline, and it now lets you know if it is unable to connect to a
         job board's site before submitting your job search query.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ Once finished, perform a job search on LinkedIn or Indeed. **_If you do not see 
 
 ## **Release Notes**
 
+- 4.2.2
+  - Release date
+    - 2023-05-14
+  - Improvements
+    - Added support for all country-specific versions of Indeed
+      - All country-specific versions of Indeed (i.e. non-US versions of Indeed) now work with Hide n' Seek. (Issue #14)
+    - Added network connectivity handling to the job search popup
+      - Hide n' Seek will now automatically disable the job search popup when your device is offline, and it now lets you know if it is unable to connect to a
+        job board's site before submitting your job search query.
 - 4.1.2
   - Release date
     - 2023-04-18

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Once finished, perform a job search on LinkedIn or Indeed. **_If you do not see 
   - Release date
     - 2023-05-14
   - Improvements
-    - Added support for all country-specific versions of Indeed
-      - All country-specific versions of Indeed (i.e. non-US versions of Indeed) now work with Hide n' Seek. ([Issue #14](https://github.com/damianmgarcia/Hide-n-Seek/issues/14))
+    - Added support for all non-US versions of Indeed
+      - All non-US versions of Indeed now work with Hide n' Seek. This update resolves [#14](https://github.com/damianmgarcia/Hide-n-Seek/issues/14).
     - Added network connectivity handling to the job search popup
       - Hide n' Seek will now automatically disable the job search popup when your device is offline, and it now lets you know if it is unable to connect to a
         job board's site before submitting your job search query.

--- a/extension/content-script/js/content-script.js
+++ b/extension/content-script/js/content-script.js
@@ -8,18 +8,21 @@
   class JobBoards {
     static #jobBoards = [
       {
-        hostname: "www.linkedin.com",
+        hostname: "linkedin.com",
         jobBoardId: "linkedIn",
       },
       {
-        hostname: "www.indeed.com",
+        hostname: "indeed.com",
         jobBoardId: "indeed",
       },
     ];
 
     static getJobBoardIdByHostname(hostname = location.hostname) {
-      return this.#jobBoards.find((jobBoard) => jobBoard.hostname === hostname)
-        ?.jobBoardId;
+      return this.#jobBoards.find(
+        (jobBoard) =>
+          hostname.endsWith(`.${jobBoard.hostname}`) ||
+          hostname === jobBoard.hostname
+      )?.jobBoardId;
     }
   }
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Hide n' Seek",
   "description": "View the jobs you seek. Hide the ones you don't.",
-  "version": "4.1.2",
+  "version": "4.2.2",
   "icons": {
     "16": "/images/hide-n-seek-icon-16.png",
     "32": "/images/hide-n-seek-icon-32.png",

--- a/extension/popup/css/popup.css
+++ b/extension/popup/css/popup.css
@@ -242,7 +242,8 @@ html[data-applicable-tab="false"] .options-for-inapplicable-tabs {
   grid-column: 2 / 3;
   grid-row: 1 / 1;
   height: auto;
-  transition: background-color 200ms ease-out;
+  transition: 200ms ease-out;
+  transition-property: background-color, opacity;
   width: 30px;
 }
 
@@ -484,6 +485,8 @@ button {
 :disabled {
   opacity: 0.1;
   pointer-events: none;
+  transition: 200ms ease-out;
+  transition-property: background-color, opacity;
 }
 
 .collapse-expand-button:disabled {
@@ -586,13 +589,21 @@ input[type="radio"] {
 }
 
 input[type="text"] {
+  background: hsl(0, 0%, 100%, 1);
   border: none;
   font-family: "Open Sans", sans-serif;
   height: 2rem;
   margin: 0;
   padding: 0;
   text-align: center;
+  transition: 200ms ease-out;
+  transition-property: background-color, opacity;
   width: 100%;
+}
+
+input[type="text"]:disabled {
+  background: hsl(0, 0%, 100%, 0.3);
+  opacity: 1;
 }
 
 ::-webkit-scrollbar {

--- a/extension/popup/css/popup.css
+++ b/extension/popup/css/popup.css
@@ -211,6 +211,10 @@ html[data-applicable-tab="false"] .options-for-inapplicable-tabs {
   fill: hsl(0, 0%, 50%);
 }
 
+.job-board-search-option-container:has(:disabled) {
+  pointer-events: none;
+}
+
 .job-board-search-option-container > input {
   position: absolute;
 }

--- a/extension/popup/css/popup.css
+++ b/extension/popup/css/popup.css
@@ -220,6 +220,7 @@ html[data-applicable-tab="false"] .options-for-inapplicable-tabs {
 }
 
 .options-for-applicable-tabs .job-board-name {
+  max-height: 32.4219px;
   width: 50%;
 }
 

--- a/extension/popup/js/popup.js
+++ b/extension/popup/js/popup.js
@@ -225,7 +225,7 @@
       });
 
       this.#checkboxInput.addEventListener("keydown", (keyboardEvent) => {
-        if (keyboardEvent.key !== "Enter") return;
+        if (keyboardEvent.key !== "Enter" || keyboardEvent.repeat) return;
 
         this.#checkboxInput.checked = this.#checkboxInput.checked
           ? false
@@ -843,7 +843,7 @@
       this.#jobNameSearchContainerInput.addEventListener(
         "keydown",
         (keyboardEvent) => {
-          if (keyboardEvent.key === "Enter")
+          if (keyboardEvent.key === "Enter" && !keyboardEvent.repeat)
             this.#search(activeTabInCurrentWindow);
         }
       );

--- a/other-manifests/firefox/manifest.json
+++ b/other-manifests/firefox/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Hide n' Seek",
   "description": "View the jobs you seek. Hide the ones you don't.",
-  "version": "4.1.2",
+  "version": "4.2.2",
   "icons": {
     "16": "/images/hide-n-seek-icon-16.png",
     "32": "/images/hide-n-seek-icon-32.png",


### PR DESCRIPTION
This release of Hide n' Seek includes the following changes:

- All non-US versions of Indeed now work with Hide n' Seek. This change resolves #14.
- The job search popup now listens for changes in connectivity and will automatically enable or disable inputs depending on whether the user's device is online or offline. If the user's device is offline, Hide n' Seek will inform the user by displaying the message "Device is offline" inside the search input field.
- Hide n' Seek will now first check that the job board site is online or not when a user searches for a job with the popup. If the job board site is offline, Hide n' Seek will inform the user by displaying a message (e.g. "Can't connect to Indeed") inside the search input field, which will also flash red for a few seconds.