### PR TITLE
Hide n' Seek 4.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ Once finished, perform a job search on LinkedIn or Indeed. **_If you do not see 
   - Release date
     - 2023-08-24
   - Bug fixes
-    - False positive job listings
+    - False positive job listings on certain pages of the signed-out version of LinkedIn
       - Job listing detection has been adjusted to eliminate false positives on certain pages of the signed-out version of LinkedIn.
+    - Missing extension button badge after pressing back/forward buttons on Indeed
+      - Hide n' Seek is now optimized so that the extension button's badge is updated even on pages that use bfcache
 - 4.2.3
   - Release date
     - 2023-08-20

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Once finished, perform a job search on LinkedIn or Indeed. **_If you do not see 
 
 ## **Release Notes**
 
+- 4.2.4
+  - Release date
+    - 2023-08-24
+  - Bug fixes
+    - False positive job listings
+      - Job listing detection has been adjusted to eliminate false positives on certain pages of the signed-out version of LinkedIn.
 - 4.2.3
   - Release date
     - 2023-08-20

--- a/extension/background/js/background.js
+++ b/extension/background/js/background.js
@@ -292,7 +292,8 @@ chrome.runtime.onMessage.addListener((message, sender) => {
 
   if (
     message.from === "content script" &&
-    message.body === "hasHideNSeekUI changed"
+    (message.body === "hasHideNSeekUI changed" ||
+      message.body === "bfcache used")
   ) {
     updateBadgeTextAndTitle(message.jobBoardId, [sender.tab]);
   }

--- a/extension/content-script/js/content-script.js
+++ b/extension/content-script/js/content-script.js
@@ -29,22 +29,17 @@
   class JobBoardSelectors {
     #selectors;
     constructor(jobBoardId) {
-      const reduceStringValues = (object) =>
-        [...new Set(Object.values(object).flat(Infinity))].join(", ");
-
       const selectors = {
         linkedIn: {
-          jobElement: {
-            jobCollection: ["li:has(.job-card-container) .job-card-container"],
-            jobSearchSignedIn: [
-              "li:has(.job-card-container) .job-card-container",
-            ],
-            jobSearchSignedOut: ["li:has(.base-card) .base-card"],
-          },
           baseElementOfJobElement: {
             jobCollection: ["li"],
             jobSearchSignedIn: ["li"],
             jobSearchSignedOut: ["li"],
+          },
+          card: {
+            jobCollection: [".job-card-container"],
+            jobSearchSignedIn: [".job-card-container"],
+            jobSearchSignedOut: [".job-search-card"],
           },
           companyName: {
             jobCollection: [".job-card-container__primary-description"],
@@ -58,13 +53,13 @@
           },
         },
         indeed: {
-          jobElement: {
-            jobFeed: ["li:has(.result) .result"],
-            jobSearch: ["li:has(.result) .result"],
-          },
           baseElementOfJobElement: {
             jobFeed: ["li"],
             jobSearch: ["li"],
+          },
+          card: {
+            jobFeed: [".result"],
+            jobSearch: [".result"],
           },
           companyName: {
             jobFeed: [".companyName"],
@@ -77,12 +72,18 @@
         },
       };
 
-      this.#selectors = Object.fromEntries(
+      const mergedSelectors = Object.fromEntries(
         Object.entries(selectors[jobBoardId]).map(([key, value]) => [
           key,
-          reduceStringValues(value),
+          [...new Set(Object.values(value).flat(Infinity))].join(", "),
         ])
       );
+
+      const { baseElementOfJobElement, card } = mergedSelectors;
+
+      mergedSelectors.jobElement = `:is(${baseElementOfJobElement}):has(${card}) :is(${card})`;
+
+      this.#selectors = mergedSelectors;
     }
 
     get selectors() {

--- a/extension/content-script/js/content-script.js
+++ b/extension/content-script/js/content-script.js
@@ -150,6 +150,18 @@
 
       this.#registerJobs();
 
+      addEventListener("pageshow", (pageTransitionEvent) => {
+        if (!pageTransitionEvent.persisted) return;
+
+        chrome.runtime.sendMessage({
+          from: "content script",
+          to: ["background script", "popup script"],
+          body: "bfcache used",
+          jobBoardId: this.#jobBoardId,
+          hasHideNSeekUI: this.#hasHideNSeekUI,
+        });
+      });
+
       this.#jobRegistrar.observe(document.documentElement, {
         subtree: true,
         childList: true,

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Hide n' Seek",
   "description": "View the jobs you seek. Hide the ones you don't. Easily hide promoted jobs and companies on LinkedIn and Indeed.",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "icons": {
     "16": "/images/hide-n-seek-icon-16.png",
     "32": "/images/hide-n-seek-icon-32.png",

--- a/extension/popup/js/popup.js
+++ b/extension/popup/js/popup.js
@@ -901,7 +901,8 @@
 
     if (
       message.from === "content script" &&
-      message.body === "hasHideNSeekUI changed"
+      (message.body === "hasHideNSeekUI changed" ||
+        message.body === "bfcache used")
     ) {
       const messageFromActiveTabInCurrentWindow =
         sender.tab.id === activeTabInCurrentWindow.id &&

--- a/other-manifests/firefox/manifest.json
+++ b/other-manifests/firefox/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Hide n' Seek",
   "description": "View the jobs you seek. Hide the ones you don't. Easily hide promoted jobs and companies on LinkedIn and Indeed.",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "icons": {
     "16": "/images/hide-n-seek-icon-16.png",
     "32": "/images/hide-n-seek-icon-32.png",


### PR DESCRIPTION
This release of Hide n' Seek includes the following changes:
- **Bug fixes**
  - Updated job listing detection to eliminate false positive job listings on certain pages of the signed-out version of LinkedIn.
    - Resolves #19 
  - Optimized content script to detect the use of bfcache so that the content script can update the background script and popup script when bfcache is used during back/forward navigation.
    - Resolves #20 