### PR TITLE
Fix compatibility with inDoors and error when exporting large json

### DIFF
--- a/extension/content-script/js/content-script.js
+++ b/extension/content-script/js/content-script.js
@@ -65,7 +65,7 @@
                   .querySelector(
                     ".job-card-container__primary-description, .job-card-container__company-name, .base-search-card__subtitle, .artdeco-entity-lockup__subtitle"
                   )
-                  ?.textContent.trim()
+                  ?.querySelector("span")?.textContent.trim()
                   .replace(/\s*·\s*.*$/, "") || "Unknown Company"
               );
             },

--- a/extension/content-script/js/content-script.js
+++ b/extension/content-script/js/content-script.js
@@ -63,9 +63,9 @@
               return (
                 jobListing
                   .querySelector(
-                    ".job-card-container__primary-description, .job-card-container__company-name, .base-search-card__subtitle, .artdeco-entity-lockup__subtitle"
+                    ".job-card-container__primary-description, .job-card-container__company-name, .base-search-card__subtitle, .artdeco-entity-lockup__subtitle > span"
                   )
-                  ?.querySelector("span")?.textContent.trim()
+                  ?.textContent.trim()
                   .replace(/\s*·\s*.*$/, "") || "Unknown Company"
               );
             },

--- a/extension/popup/js/popup.js
+++ b/extension/popup/js/popup.js
@@ -963,8 +963,11 @@
     const backup = await chrome.storage.local.get();
     delete backup.syncError;
     const jsonStorage = JSON.stringify(backup, null, 2);
+    const encodedJsonStorage = new TextEncoder().encode(jsonStorage);
     const base64Storage = btoa(
-      String.fromCodePoint(...new TextEncoder().encode(jsonStorage))
+      encodedJsonStorage.reduce(function (data, byte) {
+        return data + String.fromCodePoint(byte);
+      })
     );
     const dataUri = `data:application/json;base64,${base64Storage}`;
     const fileName = `hide-n-seek-backup-${Date.now()}.json`;


### PR DESCRIPTION
Hi, I ran into some other issues recently and I made quick fixes for them:

1. When this extension is used alongside [inDoors](https://github.com/CalvinWu4/inDoors), the selector for company names will get a wrong string because the other extension inserts a new element.
2. When exporting a very large json, the argument spread at [popup.js#L967](https://github.com/damianmgarcia/Hide-n-Seek/blob/c024a550304f6ae42ba116ab39dc9eda4864c82c/extension/popup/js/popup.js#L967) will cause `Maximum call stack size exceeded`, so I changed it into a reduce.