### PR TITLE
Hide n' Seek 9.0.2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,11 @@ The promotional video was created with a combination of Adobe After Effects and 
 
 ## **Release Notes**
 
+- 9.0.2
+  - Release date
+    - 2026-05-25
+  - Patches
+    - Remove LinkedIn auto-reload feature. This feature was meant to address an issue that required users to occasionally reload LinkedIn after switching pages in order to trigger Hide n' Seek. Unfortunately, it seems to have been causing some unnecessary reloads. Sorry about that!
 - 9.0.1
   - Release date
     - 2026-05-19

--- a/extension/chrome/content/modules/status.js
+++ b/extension/chrome/content/modules/status.js
@@ -9,7 +9,14 @@ const hnsStatus = (jobBoard) => {
     ).length,
   });
 
-  const getTabStatus = ({ sendResponse }) => sendResponse(tabStatus());
+  const getTabStatus = ({ sendResponse }) => {
+    sendResponse(tabStatus());
+    const isLinkedInJobCollectionIframe =
+      jobBoard.id === "linkedIn" &&
+      location.pathname.startsWith("/jobs/collections") &&
+      document.querySelector("iframe[data-testid='interop-iframe']");
+    if (isLinkedInJobCollectionIframe) location.reload();
+  };
 
   const sendTabStatus = () =>
     chrome.runtime.sendMessage({

--- a/extension/chrome/manifest.json
+++ b/extension/chrome/manifest.json
@@ -3,7 +3,7 @@
   "name": "Hide n' Seek: Hide Promoted Jobs & Companies",
   "short_name": "Hide n' Seek",
   "description": "View the jobs you seek. Hide the ones you don't. Easily hide promoted jobs, companies, and more on LinkedIn, Indeed, and Glassdoor.",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "icons": {
     "16": "/assets/images/hide-n-seek-icon-16.png",
     "32": "/assets/images/hide-n-seek-icon-32.png",

--- a/extension/chrome/runtime/modules/job-boards.js
+++ b/extension/chrome/runtime/modules/job-boards.js
@@ -256,23 +256,4 @@ const getJobBoardById = (() => {
   return (id) => jobBoardById[id];
 })();
 
-const getJobBoardTabs = async (filters = {}) => {
-  const tabs = await chrome.tabs.query({
-    url:
-      filters.matchPatterns ||
-      (filters.jobBoardId &&
-        getJobBoardById(filters.jobBoardId)?.matchPatterns.listingPages) ||
-      matchPatterns.listingPages,
-    windowType: "normal",
-  });
-
-  return tabs.filter((tab) => getJobBoardByUrl(tab.url));
-};
-
-export {
-  jobBoards,
-  matchPatterns,
-  getJobBoardByUrl,
-  getJobBoardById,
-  getJobBoardTabs,
-};
+export { jobBoards, matchPatterns, getJobBoardByUrl, getJobBoardById };

--- a/extension/chrome/runtime/modules/permissions.js
+++ b/extension/chrome/runtime/modules/permissions.js
@@ -1,5 +1,4 @@
-import { getJobBoardTabs } from "./job-boards.js";
-import { reloadTabs } from "./tabs.js";
+import { getJobBoardTabs, reloadTabs } from "./tabs.js";
 
 const hasOriginPermissions = async (origins) =>
   chrome.permissions.contains({ origins });

--- a/extension/chrome/runtime/modules/tabs.js
+++ b/extension/chrome/runtime/modules/tabs.js
@@ -1,5 +1,23 @@
-import { jobBoards, getJobBoardTabs, getJobBoardByUrl } from "./job-boards.js";
+import {
+  getJobBoardById,
+  getJobBoardByUrl,
+  jobBoards,
+  matchPatterns,
+} from "./job-boards.js";
 import { hasOriginPermissions } from "./permissions.js";
+
+const getJobBoardTabs = async (filters = {}) => {
+  const tabs = await chrome.tabs.query({
+    url:
+      filters.matchPatterns ||
+      (filters.jobBoardId &&
+        getJobBoardById(filters.jobBoardId)?.matchPatterns.listingPages) ||
+      matchPatterns.listingPages,
+    windowType: "normal",
+  });
+
+  return tabs.filter((tab) => getJobBoardByUrl(tab.url));
+};
 
 const getActiveTab = async () => {
   const [activeTab] = await chrome.tabs.query({
@@ -18,13 +36,12 @@ const defaultTabStatus = {
 
 const getTabStatus = async (tab) => {
   try {
-    const tabStatus =
-      (await chrome.tabs.sendMessage(tab.id, {
-        request: "get tab status",
-      })) || defaultTabStatus;
-    return { ...tabStatus, hasContentScript: true };
+    const tabStatus = await chrome.tabs.sendMessage(tab.id, {
+      request: "get tab status",
+    });
+    return tabStatus || defaultTabStatus;
   } catch {
-    return { ...defaultTabStatus, hasContentScript: false };
+    return defaultTabStatus;
   }
 };
 
@@ -92,50 +109,32 @@ const reloadTabs = async (tabs) => {
   } catch {}
 };
 
-let tabHistory = {};
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (!tab || !tab.url) return;
-  const jobBoardByUrl = getJobBoardByUrl(tab.url);
-  const tabStatus = await getTabStatus(tab);
-  if (!jobBoardByUrl) {
-    if (changeInfo.url && tabStatus.hasContentScript) {
-      reloadTabs([tab]);
-    }
-    return;
-  }
-  if (await hasOriginPermissions(jobBoardByUrl.matchPatterns.origins)) {
-    if (changeInfo.url && jobBoardByUrl.isSPA) {
-      if (!tabHistory[tabId]) {
-        tabHistory[tabId] = changeInfo.url;
-        return;
-      }
-      if (!URL.canParse(tabHistory[tabId]) || !URL.canParse(changeInfo.url)) {
-        tabHistory[tabId] = changeInfo.url;
-        reloadTabs([tab]);
-        return;
-      }
-      const oldUrl = new URL(tabHistory[tabId]);
-      const newUrl = new URL(changeInfo.url);
-      const pathChanged =
-        oldUrl.origin !== newUrl.origin || oldUrl.pathname !== newUrl.pathname;
-      tabHistory[tabId] = changeInfo.url;
-      if (pathChanged) reloadTabs([tab]);
-      return;
-    }
-    if (!tabStatus.hasListings) {
-      updateBadge(tab, { title: "", text: "" });
-    }
-  } else {
+  const jobBoard = getJobBoardByUrl(tab.url);
+  if (!jobBoard) return;
+  const originPermissions = await hasOriginPermissions(
+    jobBoard.matchPatterns.origins,
+  );
+  if (!originPermissions) {
     updateBadge(tab, {
-      title: `Hide n' Seek needs to be enabled on ${jobBoardByUrl.name}`,
+      title: `Hide n' Seek needs to be enabled on ${jobBoard.name}`,
       text: "!",
       backgroundColor: [255, 255, 0, 255],
     });
+  } else {
+    const jobBoardStatus = await getTabStatus(tab);
+    if (!jobBoardStatus.hasListings) {
+      updateBadge(tab, { title: "", text: "" });
+    }
   }
 });
 
-chrome.tabs.onRemoved.addListener((tabId) => {
-  delete tabHistory[tabId];
-});
-
-export { getActiveTab, getTabStatus, updateBadge, updateBadges, reloadTabs };
+export {
+  getActiveTab,
+  getJobBoardTabs,
+  getTabStatus,
+  updateBadge,
+  updateBadges,
+  reloadTabs,
+};

--- a/extension/firefox/manifest.json
+++ b/extension/firefox/manifest.json
@@ -3,7 +3,7 @@
   "name": "Hide n' Seek: Hide Promoted Jobs & Companies",
   "short_name": "Hide n' Seek",
   "description": "View the jobs you seek. Hide the ones you don't. Easily hide promoted jobs, companies, and more on LinkedIn, Indeed, and Glassdoor.",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "icons": {
     "16": "/assets/images/hide-n-seek-icon-16.png",
     "32": "/assets/images/hide-n-seek-icon-32.png",


### PR DESCRIPTION
- Patches
  - Remove LinkedIn auto-reload feature. This feature was meant to address an issue that required users to occasionally reload LinkedIn after switching pages in order to trigger Hide n' Seek. Unfortunately, it seems to have been causing some unnecessary reloads. Sorry about that!